### PR TITLE
Fix Swift 6 Sendable error in PublicKeyCache

### DIFF
--- a/Sources/AlgoChat/AlgoChat.swift
+++ b/Sources/AlgoChat/AlgoChat.swift
@@ -362,7 +362,8 @@ public actor AlgoChat {
         for address: Address
     ) async throws -> Curve25519.KeyAgreement.PublicKey {
         // Check cache first
-        if let cached = await publicKeyCache.retrieve(for: address) {
+        if let cachedData = await publicKeyCache.retrieve(for: address),
+           let cached = try? Curve25519.KeyAgreement.PublicKey(rawRepresentation: cachedData) {
             return cached
         }
 
@@ -370,7 +371,7 @@ public actor AlgoChat {
         let discovered = try await indexer.findPublicKey(for: address)
 
         // Cache for future lookups
-        await publicKeyCache.store(discovered.publicKey, for: address)
+        await publicKeyCache.store(discovered.publicKey.rawRepresentation, for: address)
 
         return discovered.publicKey
     }

--- a/Tests/AlgoChatTests/CacheTests.swift
+++ b/Tests/AlgoChatTests/CacheTests.swift
@@ -146,10 +146,10 @@ struct PublicKeyCacheTests {
         let cache = PublicKeyCache()
         let key = Curve25519.KeyAgreement.PrivateKey().publicKey
 
-        await cache.store(key, for: testAddress)
+        await cache.store(key.rawRepresentation, for: testAddress)
         let retrieved = await cache.retrieve(for: testAddress)
 
-        #expect(retrieved?.rawRepresentation == key.rawRepresentation)
+        #expect(retrieved == key.rawRepresentation)
     }
 
     @Test("Returns nil for non-existent key")
@@ -164,7 +164,7 @@ struct PublicKeyCacheTests {
         let cache = PublicKeyCache()
         let key = Curve25519.KeyAgreement.PrivateKey().publicKey
 
-        await cache.store(key, for: testAddress)
+        await cache.store(key.rawRepresentation, for: testAddress)
         await cache.invalidate(for: testAddress)
 
         let retrieved = await cache.retrieve(for: testAddress)
@@ -176,7 +176,7 @@ struct PublicKeyCacheTests {
         let cache = PublicKeyCache()
         let key = Curve25519.KeyAgreement.PrivateKey().publicKey
 
-        await cache.store(key, for: testAddress)
+        await cache.store(key.rawRepresentation, for: testAddress)
         await cache.clear()
 
         let retrieved = await cache.retrieve(for: testAddress)
@@ -189,7 +189,7 @@ struct PublicKeyCacheTests {
         let cache = PublicKeyCache(ttl: 0.1)  // 100ms TTL
         let key = Curve25519.KeyAgreement.PrivateKey().publicKey
 
-        await cache.store(key, for: testAddress)
+        await cache.store(key.rawRepresentation, for: testAddress)
 
         // Wait for expiration
         try await Task.sleep(nanoseconds: 200_000_000)  // 200ms
@@ -203,12 +203,12 @@ struct PublicKeyCacheTests {
         let cache = PublicKeyCache(ttl: 10)  // 10 second TTL
         let key = Curve25519.KeyAgreement.PrivateKey().publicKey
 
-        await cache.store(key, for: testAddress)
+        await cache.store(key.rawRepresentation, for: testAddress)
 
         // Small wait (well under TTL)
         try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
 
         let retrieved = await cache.retrieve(for: testAddress)
-        #expect(retrieved?.rawRepresentation == key.rawRepresentation)
+        #expect(retrieved == key.rawRepresentation)
     }
 }


### PR DESCRIPTION
## Summary
- Fix build error caused by `Curve25519.KeyAgreement.PublicKey` not being `Sendable`
- Changed `PublicKeyCacheProtocol` to use `Data` (raw bytes) instead of `PublicKey` directly
- Keys are reconstructed from raw representation at the call site in `AlgoChat.fetchPublicKey()`

## Test Plan
- [x] `swift build` succeeds
- [x] `swift test --filter CacheTests` passes (13 tests)
- [x] CLI runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)