### PR TITLE
Fix: Sent messages cannot be decrypted when loading from blockchain

### DIFF
--- a/Sources/AlgoChat/Blockchain/MessageIndexer.swift
+++ b/Sources/AlgoChat/Blockchain/MessageIndexer.swift
@@ -30,6 +30,9 @@ public actor MessageIndexer {
     ) async throws -> [Message] {
         var allMessages: [Message] = []
 
+        // Look up participant's public key for decrypting sent messages
+        let participantKey = try? await findPublicKey(for: participant)
+
         // Fetch transactions involving our account
         let response = try await indexerClient.searchTransactions(
             address: chatAccount.address,
@@ -66,7 +69,12 @@ public actor MessageIndexer {
             }
 
             // Try to parse and decrypt the message
-            if let message = try? parseMessage(from: tx, direction: direction) {
+            // For sent messages, pass the participant's public key
+            if let message = try? parseMessage(
+                from: tx,
+                direction: direction,
+                recipientPublicKey: direction == .sent ? participantKey : nil
+            ) {
                 allMessages.append(message)
             }
         }
@@ -209,7 +217,8 @@ public actor MessageIndexer {
 
     private func parseMessage(
         from tx: IndexerTransaction,
-        direction: Message.Direction
+        direction: Message.Direction,
+        recipientPublicKey: Curve25519.KeyAgreement.PublicKey? = nil
     ) throws -> Message? {
         guard let noteData = tx.noteData else {
             throw ChatError.invalidEnvelope("No note data")
@@ -219,10 +228,24 @@ public actor MessageIndexer {
 
         // Decrypt the message (returns structured content with optional reply metadata)
         // Returns nil for key-publish payloads, which should be filtered out
-        guard let decrypted = try MessageEncryptor.decrypt(
-            envelope: envelope,
-            recipientPrivateKey: chatAccount.encryptionPrivateKey
-        ) else {
+        let decrypted: DecryptedContent?
+
+        if direction == .sent, let recipientKey = recipientPublicKey {
+            // For sent messages, use decryptSent with the recipient's public key
+            decrypted = try MessageEncryptor.decryptSent(
+                envelope: envelope,
+                senderPrivateKey: chatAccount.encryptionPrivateKey,
+                recipientPublicKey: recipientKey
+            )
+        } else {
+            // For received messages, use normal decrypt
+            decrypted = try MessageEncryptor.decrypt(
+                envelope: envelope,
+                recipientPrivateKey: chatAccount.encryptionPrivateKey
+            )
+        }
+
+        guard let decrypted else {
             // Key-publish payload - not a real message
             return nil
         }

--- a/Sources/AlgoChat/Crypto/MessageEncryptor.swift
+++ b/Sources/AlgoChat/Crypto/MessageEncryptor.swift
@@ -169,6 +169,75 @@ public enum MessageEncryptor {
         return DecryptedContent(text: message)
     }
 
+    /// Decrypts a sent message envelope using the recipient's public key
+    ///
+    /// When you sent a message, you encrypted with your_private + recipient_public.
+    /// To decrypt your own sent message, you need the recipient's public key.
+    ///
+    /// - Parameters:
+    ///   - envelope: The encrypted envelope
+    ///   - senderPrivateKey: Your X25519 private key (you sent this message)
+    ///   - recipientPublicKey: Recipient's X25519 public key
+    /// - Returns: DecryptedContent with text, or nil for key-publish
+    public static func decryptSent(
+        envelope: ChatEnvelope,
+        senderPrivateKey: Curve25519.KeyAgreement.PrivateKey,
+        recipientPublicKey: Curve25519.KeyAgreement.PublicKey
+    ) throws -> DecryptedContent? {
+        // Derive shared secret using recipient's public key
+        let sharedSecret = try senderPrivateKey.sharedSecretFromKeyAgreement(
+            with: recipientPublicKey
+        )
+
+        // Derive symmetric key
+        let symmetricKey = sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data(),
+            sharedInfo: sharedInfo,
+            outputByteCount: 32
+        )
+
+        // Extract ciphertext and tag
+        let ciphertextLength = envelope.ciphertext.count - ChatEnvelope.tagSize
+        guard ciphertextLength > 0 else {
+            throw ChatError.decryptionFailed("Ciphertext too short")
+        }
+
+        let ciphertext = envelope.ciphertext.prefix(ciphertextLength)
+        let tag = envelope.ciphertext.suffix(ChatEnvelope.tagSize)
+
+        // Reconstruct sealed box and decrypt
+        let nonce = try ChaChaPoly.Nonce(data: envelope.nonce)
+        let sealedBox = try ChaChaPoly.SealedBox(
+            nonce: nonce,
+            ciphertext: ciphertext,
+            tag: tag
+        )
+
+        let plaintext = try ChaChaPoly.open(sealedBox, using: symmetricKey)
+
+        // Check for key-publish payload
+        if KeyPublishPayload.isKeyPublish(plaintext) {
+            return nil
+        }
+
+        // Parse as structured or plain text
+        if plaintext.first == UInt8(ascii: "{"),
+           let payload = try? JSONDecoder().decode(MessagePayload.self, from: plaintext) {
+            return DecryptedContent(
+                text: payload.text,
+                replyToId: payload.replyTo?.txid,
+                replyToPreview: payload.replyTo?.preview
+            )
+        }
+
+        guard let message = String(data: plaintext, encoding: .utf8) else {
+            throw ChatError.decryptionFailed("Decrypted data is not valid UTF-8")
+        }
+
+        return DecryptedContent(text: message)
+    }
+
     /// Internal method to decrypt envelope to raw data
     private static func decryptData(
         envelope: ChatEnvelope,


### PR DESCRIPTION
## Summary
- Add `decryptSent()` method to `MessageEncryptor` that accepts the recipient's public key
- Update `fetchMessages()` to look up participant's key before processing
- Update `parseMessage()` to use `decryptSent()` for sent messages

Fixes #5

## Test plan
- [x] Sent messages decrypt correctly when loading from blockchain
- [x] Received messages still decrypt correctly
- [x] Tested on testnet with real transactions

🤖 Generated with [Claude Code](https://claude.ai/code)