### PR TITLE
fix: verify encryption key signatures in key discovery

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run tests (batch 1 — crypto + envelope)
       run: >-
         swift test -v
-        --filter "ChatEnvelope|MessageEncryptor|KeyDerivation|KeyStorage"
+        --filter "ChatEnvelope|MessageEncryptor|KeyDerivation|KeyStorage|KeyVerification"
     - name: Run tests (batch 2 — unit + non-crypto)
       run: >-
         swift test -v

--- a/Sources/AlgoChat/AlgoChat.swift
+++ b/Sources/AlgoChat/AlgoChat.swift
@@ -501,16 +501,22 @@ public actor AlgoChat {
             recipientPublicKey: account.encryptionPublicKey
         )
 
+        // Sign the encryption public key with the account's Ed25519 key
+        // This proves the encryption key was published by the account owner
+        let keySignature = try SignatureVerifier.sign(
+            encryptionPublicKey: account.encryptionPublicKey.rawRepresentation,
+            with: account.account
+        )
+
         // Get transaction parameters
         let params = try await algokit.algodClient.transactionParams()
 
-        // Create zero-value self-payment (just publishes the key in the note)
-        let signedTx = try MessageTransaction.createSigned(
+        // Create zero-value self-payment with signed key announcement
+        let signedTx = try MessageTransaction.createSignedKeyPublish(
             from: account,
-            to: account.address,
             envelope: envelope,
-            params: params,
-            amount: MicroAlgos(0)
+            keySignature: keySignature,
+            params: params
         )
 
         // Submit transaction

--- a/Sources/AlgoChat/Blockchain/MessageIndexer.swift
+++ b/Sources/AlgoChat/Blockchain/MessageIndexer.swift
@@ -166,6 +166,9 @@ public actor MessageIndexer {
             limit: searchDepth
         )
 
+        // Track the best unverified key as fallback
+        var unverifiedKey: DiscoveredKey?
+
         for tx in response.transactions {
             guard tx.sender == address.description,
                   let noteData = tx.noteData,
@@ -173,24 +176,31 @@ public actor MessageIndexer {
                 continue
             }
 
-            // Try to decode as either standard or PSK envelope
-            guard let decoded = try? EnvelopeDecoder.decode(from: noteData) else {
+            guard let discoveredKey = try? Self.extractKey(
+                from: noteData,
+                senderAddress: address
+            ) else {
                 continue
             }
 
-            let senderPublicKeyData: Data
-            switch decoded {
-            case .standard(let envelope):
-                senderPublicKeyData = envelope.senderPublicKey
-            case .psk(let envelope):
-                senderPublicKeyData = envelope.senderPublicKey
+            // Prefer verified keys from signed self-transfers
+            let isSelfTransfer = tx.paymentTransaction?.receiver == address.description
+            if isSelfTransfer, discoveredKey.isVerified {
+                return discoveredKey
             }
 
-            let publicKey = try KeyDerivation.decodePublicKey(from: senderPublicKeyData)
-            // Keys extracted from message envelopes are unverified — the envelope
-            // contains no Ed25519 signature proving the key belongs to the sender.
-            // Only keys from signed key announcements (V3) should be marked verified.
-            return DiscoveredKey(publicKey: publicKey, isVerified: false)
+            // Save first unverified key as fallback
+            if unverifiedKey == nil {
+                unverifiedKey = DiscoveredKey(
+                    publicKey: discoveredKey.publicKey,
+                    isVerified: false
+                )
+            }
+        }
+
+        // Return unverified key if no verified one was found
+        if let unverifiedKey {
+            return unverifiedKey
         }
 
         throw ChatError.publicKeyNotFound(address.description)
@@ -251,6 +261,61 @@ public actor MessageIndexer {
         }
 
         return false
+    }
+
+    // MARK: - Key Verification
+
+    /**
+     Checks if note data contains a verified key announcement
+
+     A signed key announcement is a standard ChatEnvelope with a 64-byte
+     Ed25519 signature appended. The signature is over the sender's X25519
+     encryption public key.
+
+     - Parameters:
+       - noteData: The raw transaction note data
+       - senderAddress: The Algorand address of the transaction sender
+     - Returns: The discovered key with verification status, or nil if not a chat message
+     */
+    public static func extractKey(
+        from noteData: Data,
+        senderAddress: Address
+    ) throws -> DiscoveredKey? {
+        guard EnvelopeDecoder.isChatMessage(noteData) else {
+            return nil
+        }
+
+        guard let decoded = try? EnvelopeDecoder.decode(from: noteData) else {
+            return nil
+        }
+
+        let senderPublicKeyData: Data
+        let envelopeSize: Int
+        switch decoded {
+        case .standard(let envelope):
+            senderPublicKeyData = envelope.senderPublicKey
+            envelopeSize = envelope.encode().count
+        case .psk(let envelope):
+            senderPublicKeyData = envelope.senderPublicKey
+            envelopeSize = envelope.encode().count
+        }
+
+        let publicKey = try KeyDerivation.decodePublicKey(from: senderPublicKeyData)
+
+        // Check for appended Ed25519 signature (64 bytes after envelope)
+        let remainingBytes = noteData.count - envelopeSize
+        if remainingBytes == SignatureVerifier.signatureSize {
+            let signature = noteData.suffix(SignatureVerifier.signatureSize)
+            let isValid = (try? SignatureVerifier.verify(
+                encryptionPublicKey: senderPublicKeyData,
+                signedBy: senderAddress,
+                signature: Data(signature)
+            )) ?? false
+
+            return DiscoveredKey(publicKey: publicKey, isVerified: isValid)
+        }
+
+        return DiscoveredKey(publicKey: publicKey, isVerified: false)
     }
 
     // MARK: - Private

--- a/Sources/AlgoChat/Blockchain/MessageIndexer.swift
+++ b/Sources/AlgoChat/Blockchain/MessageIndexer.swift
@@ -290,21 +290,25 @@ public actor MessageIndexer {
         }
 
         let senderPublicKeyData: Data
-        let envelopeSize: Int
+        let headerSize: Int
         switch decoded {
         case .standard(let envelope):
             senderPublicKeyData = envelope.senderPublicKey
-            envelopeSize = envelope.encode().count
+            headerSize = ChatEnvelope.headerSize
         case .psk(let envelope):
             senderPublicKeyData = envelope.senderPublicKey
-            envelopeSize = envelope.encode().count
+            headerSize = PSKEnvelope.headerSize
         }
 
         let publicKey = try KeyDerivation.decodePublicKey(from: senderPublicKeyData)
 
         // Check for appended Ed25519 signature (64 bytes after envelope)
-        let remainingBytes = noteData.count - envelopeSize
-        if remainingBytes == SignatureVerifier.signatureSize {
+        // Note: EnvelopeDecoder.decode absorbs all trailing bytes into ciphertext,
+        // so we can't use envelope.encode().count to find the boundary.
+        // Instead, check if the last 64 bytes form a valid signature.
+        // The minimum note size with a signature is: header + tag + signature
+        let minSizeWithSignature = headerSize + ChatEnvelope.tagSize + SignatureVerifier.signatureSize
+        if noteData.count >= minSizeWithSignature {
             let signature = noteData.suffix(SignatureVerifier.signatureSize)
             let isValid = (try? SignatureVerifier.verify(
                 encryptionPublicKey: senderPublicKeyData,
@@ -312,7 +316,9 @@ public actor MessageIndexer {
                 signature: Data(signature)
             )) ?? false
 
-            return DiscoveredKey(publicKey: publicKey, isVerified: isValid)
+            if isValid {
+                return DiscoveredKey(publicKey: publicKey, isVerified: true)
+            }
         }
 
         return DiscoveredKey(publicKey: publicKey, isVerified: false)

--- a/Sources/AlgoChat/Blockchain/MessageTransaction.swift
+++ b/Sources/AlgoChat/Blockchain/MessageTransaction.swift
@@ -58,6 +58,44 @@ public enum MessageTransaction {
         return try SignedTransaction.sign(tx, with: sender.account)
     }
 
+    /**
+     Creates a signed key-publish transaction with an Ed25519 signature
+
+     The note contains the envelope followed by a 64-byte Ed25519 signature
+     over the sender's X25519 encryption key. This proves the encryption key
+     was published by the holder of the Algorand account.
+
+     - Parameters:
+       - sender: The sending chat account
+       - envelope: The encrypted key-publish envelope
+       - keySignature: Ed25519 signature over the sender's encryption public key (64 bytes)
+       - params: Transaction parameters from the network
+     - Returns: Signed transaction
+     */
+    public static func createSignedKeyPublish(
+        from sender: ChatAccount,
+        envelope: ChatEnvelope,
+        keySignature: Data,
+        params: TransactionParams
+    ) throws -> SignedTransaction {
+        var noteData = envelope.encode()
+        noteData.append(keySignature)
+
+        guard noteData.count <= 1024 else {
+            throw ChatError.messageTooLarge(maxSize: 1024)
+        }
+
+        let tx = try PaymentTransactionBuilder()
+            .sender(sender.address)
+            .receiver(sender.address)
+            .amount(MicroAlgos(0))
+            .note(noteData)
+            .params(params)
+            .build()
+
+        return try SignedTransaction.sign(tx, with: sender.account)
+    }
+
     // MARK: - PSK Envelope Overloads
 
     /**

--- a/Tests/AlgoChatTests/KeyVerificationTests.swift
+++ b/Tests/AlgoChatTests/KeyVerificationTests.swift
@@ -1,0 +1,221 @@
+import Algorand
+@preconcurrency import Crypto
+import Foundation
+import Testing
+@testable import AlgoChat
+
+@Suite("Key Verification Tests")
+struct KeyVerificationTests {
+    // MARK: - extractKey Tests
+
+    @Test("Unsigned envelope returns isVerified false")
+    func testUnsignedEnvelopeReturnsUnverified() throws {
+        let account = try ChatAccount()
+        let recipientKey = Curve25519.KeyAgreement.PrivateKey()
+
+        let envelope = try MessageEncryptor.encrypt(
+            message: "hello",
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: recipientKey.publicKey
+        )
+
+        let noteData = envelope.encode()
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result != nil)
+        #expect(result!.isVerified == false)
+        #expect(result!.publicKey.rawRepresentation == account.encryptionPublicKey.rawRepresentation)
+    }
+
+    @Test("Signed key announcement returns isVerified true")
+    func testSignedKeyAnnouncementReturnsVerified() throws {
+        let account = try ChatAccount()
+
+        // Create envelope (self-encrypted for key-publish)
+        let envelope = try MessageEncryptor.encryptRaw(
+            Data("{\"type\":\"key-publish\"}".utf8),
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: account.encryptionPublicKey
+        )
+
+        // Sign the encryption public key with Ed25519
+        let signature = try SignatureVerifier.sign(
+            encryptionPublicKey: account.encryptionPublicKey.rawRepresentation,
+            with: account.account
+        )
+
+        // Append signature to note data (same format as createSignedKeyPublish)
+        var noteData = envelope.encode()
+        noteData.append(signature)
+
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result != nil)
+        #expect(result!.isVerified == true)
+        #expect(result!.publicKey.rawRepresentation == account.encryptionPublicKey.rawRepresentation)
+    }
+
+    @Test("Signature from wrong account returns isVerified false")
+    func testWrongAccountSignatureReturnsUnverified() throws {
+        let account = try ChatAccount()
+        let wrongAccount = try ChatAccount()
+
+        let envelope = try MessageEncryptor.encryptRaw(
+            Data("{\"type\":\"key-publish\"}".utf8),
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: account.encryptionPublicKey
+        )
+
+        // Sign with the wrong account's Ed25519 key
+        let wrongSignature = try SignatureVerifier.sign(
+            encryptionPublicKey: account.encryptionPublicKey.rawRepresentation,
+            with: wrongAccount.account
+        )
+
+        var noteData = envelope.encode()
+        noteData.append(wrongSignature)
+
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result != nil)
+        #expect(result!.isVerified == false)
+    }
+
+    @Test("Corrupted signature returns isVerified false")
+    func testCorruptedSignatureReturnsUnverified() throws {
+        let account = try ChatAccount()
+
+        let envelope = try MessageEncryptor.encryptRaw(
+            Data("{\"type\":\"key-publish\"}".utf8),
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: account.encryptionPublicKey
+        )
+
+        // Append garbage 64-byte "signature"
+        var noteData = envelope.encode()
+        noteData.append(Data(repeating: 0xFF, count: 64))
+
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result != nil)
+        #expect(result!.isVerified == false)
+    }
+
+    @Test("Non-chat data returns nil")
+    func testNonChatDataReturnsNil() throws {
+        let account = try ChatAccount()
+        let noteData = Data("not a chat message".utf8)
+
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("PSK envelope without signature returns isVerified false")
+    func testPSKEnvelopeReturnsUnverified() throws {
+        let account = try ChatAccount()
+        let recipientKey = Curve25519.KeyAgreement.PrivateKey()
+        let psk = Data(repeating: 0xAB, count: 32)
+
+        let envelope = try MessageEncryptor.encryptPSK(
+            message: "hello",
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: recipientKey.publicKey,
+            currentPSK: psk,
+            ratchetCounter: 1
+        )
+
+        let noteData = envelope.encode()
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        #expect(result != nil)
+        #expect(result!.isVerified == false)
+    }
+
+    // MARK: - MessageTransaction.createSignedKeyPublish Tests
+
+    @Test("createSignedKeyPublish appends signature to note data")
+    func testCreateSignedKeyPublishAppendsSignature() throws {
+        let account = try ChatAccount()
+
+        let envelope = try MessageEncryptor.encryptRaw(
+            Data("{\"type\":\"key-publish\"}".utf8),
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: account.encryptionPublicKey
+        )
+
+        let signature = try SignatureVerifier.sign(
+            encryptionPublicKey: account.encryptionPublicKey.rawRepresentation,
+            with: account.account
+        )
+
+        #expect(signature.count == SignatureVerifier.signatureSize)
+
+        // Verify the note format: envelope + 64-byte signature
+        let envelopeData = envelope.encode()
+        var expectedNote = envelopeData
+        expectedNote.append(signature)
+
+        #expect(expectedNote.count == envelopeData.count + 64)
+        #expect(expectedNote.count <= 1024) // Fits in Algorand note field
+    }
+
+    // MARK: - DiscoveredKey Tests
+
+    @Test("DiscoveredKey preserves verification status")
+    func testDiscoveredKeyPreservesVerification() throws {
+        let key = Curve25519.KeyAgreement.PrivateKey().publicKey
+
+        let verified = DiscoveredKey(publicKey: key, isVerified: true)
+        let unverified = DiscoveredKey(publicKey: key, isVerified: false)
+
+        #expect(verified.isVerified == true)
+        #expect(unverified.isVerified == false)
+        #expect(verified.publicKey.rawRepresentation == unverified.publicKey.rawRepresentation)
+    }
+
+    @Test("Partial signature data (wrong size) returns isVerified false")
+    func testPartialSignatureReturnsUnverified() throws {
+        let account = try ChatAccount()
+
+        let envelope = try MessageEncryptor.encryptRaw(
+            Data("{\"type\":\"key-publish\"}".utf8),
+            senderPrivateKey: account.encryptionPrivateKey,
+            recipientPublicKey: account.encryptionPublicKey
+        )
+
+        // Append only 32 bytes (not 64) — should not be treated as a signature
+        var noteData = envelope.encode()
+        noteData.append(Data(repeating: 0xAA, count: 32))
+
+        let result = try MessageIndexer.extractKey(
+            from: noteData,
+            senderAddress: account.address
+        )
+
+        // With wrong-sized trailing data, the envelope decode may fail
+        // because ChatEnvelope will try to include the extra bytes as ciphertext.
+        // Either way, the key should not be verified.
+        if let result {
+            #expect(result.isVerified == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #15 — `DiscoveredKey.isVerified` was hardcoded to `true` without any signature verification.

- **`MessageIndexer.findPublicKey()`**: Now returns `isVerified: true` only for signed key announcements (self-transfers with a 64-byte Ed25519 signature appended to the envelope), and `isVerified: false` for keys from regular message envelopes
- **`MessageIndexer.extractKey(from:senderAddress:)`**: New public static method that extracts and verifies keys from raw note data — decoupled from indexer for testability
- **`MessageTransaction.createSignedKeyPublish()`**: New method that creates key-publish transactions with Ed25519 signatures appended to the note
- **`AlgoChat.publishKey()`**: Updated to sign the encryption key with Ed25519 before publishing
- **CI**: Added `KeyVerification` to the test filter

## Test plan

- [x] `swift build` passes
- [ ] `KeyVerificationTests` — 8 tests covering: unsigned envelopes return unverified, signed announcements return verified, wrong-account signatures fail, corrupted signatures fail, non-chat data returns nil, PSK envelopes return unverified, note format validation, partial signature handling
- [ ] CI passes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)