### PR TITLE
fix: return isVerified false for unverified envelope keys

### DIFF
--- a/Sources/AlgoChat/Blockchain/MessageIndexer.swift
+++ b/Sources/AlgoChat/Blockchain/MessageIndexer.swift
@@ -187,7 +187,10 @@ public actor MessageIndexer {
             }
 
             let publicKey = try KeyDerivation.decodePublicKey(from: senderPublicKeyData)
-            return DiscoveredKey(publicKey: publicKey, isVerified: true)
+            // Keys extracted from message envelopes are unverified — the envelope
+            // contains no Ed25519 signature proving the key belongs to the sender.
+            // Only keys from signed key announcements (V3) should be marked verified.
+            return DiscoveredKey(publicKey: publicKey, isVerified: false)
         }
 
         throw ChatError.publicKeyNotFound(address.description)

--- a/Tests/AlgoChatTests/DiscoveredKeyTests.swift
+++ b/Tests/AlgoChatTests/DiscoveredKeyTests.swift
@@ -1,0 +1,36 @@
+@preconcurrency import Crypto
+import Foundation
+import Testing
+@testable import AlgoChat
+
+@Suite("DiscoveredKey Tests")
+struct DiscoveredKeyTests {
+    @Test("Unverified key has isVerified false")
+    func testUnverifiedKey() throws {
+        let key = Curve25519.KeyAgreement.PrivateKey()
+        let discovered = DiscoveredKey(publicKey: key.publicKey, isVerified: false)
+
+        #expect(discovered.isVerified == false)
+        #expect(discovered.publicKey.rawRepresentation == key.publicKey.rawRepresentation)
+    }
+
+    @Test("Verified key has isVerified true")
+    func testVerifiedKey() throws {
+        let key = Curve25519.KeyAgreement.PrivateKey()
+        let discovered = DiscoveredKey(publicKey: key.publicKey, isVerified: true)
+
+        #expect(discovered.isVerified == true)
+    }
+
+    @Test("Keys from different sources preserve verification status")
+    func testVerificationStatusPreserved() throws {
+        let key = Curve25519.KeyAgreement.PrivateKey()
+
+        let unverified = DiscoveredKey(publicKey: key.publicKey, isVerified: false)
+        let verified = DiscoveredKey(publicKey: key.publicKey, isVerified: true)
+
+        // Same key, different verification status
+        #expect(unverified.publicKey.rawRepresentation == verified.publicKey.rawRepresentation)
+        #expect(unverified.isVerified != verified.isVerified)
+    }
+}


### PR DESCRIPTION
## Summary

- **Security fix**: `MessageIndexer.findPublicKey()` returned `isVerified: true` for keys extracted from message envelopes, but no Ed25519 signature verification was performed. Changed to `isVerified: false` to accurately reflect the unverified state.
- **Tests**: Added `DiscoveredKeyTests` suite covering verified/unverified key construction and status preservation.

## Context

Keys discovered from V1/V2 message envelopes contain no signature proving ownership. The `SignatureVerifier` exists but was never called during key discovery. Code relying on `isVerified` would incorrectly trust unverified keys.

Only signed key announcements (future V3 envelope with Ed25519 signature) should return `isVerified: true`.

**Note**: CI test filter in `macOS.yml` should be updated to include `SignatureVerifier|DiscoveredKey` — omitted from this PR due to token scope limitations.

Closes #15

## Test plan

- [ ] CI builds and existing tests pass
- [ ] New `DiscoveredKeyTests` pass (3 tests)
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)