### PR TITLE
ci: add 3 missing test suites and fix Linux parity

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Run tests (batch 1 — crypto + envelope)
         run: >-
           swift test -v
-          --filter "ChatEnvelope|MessageEncryptor|KeyDerivation|KeyStorage"
+          --filter "ChatEnvelope|MessageEncryptor|KeyDerivation|KeyStorage|KeyVerification"
       - name: Run tests (batch 2 — unit + non-crypto)
         run: >-
           swift test -v
-          --filter "ChatErrorTests|CustomAmountTests/|MessageCodableTests|MessageDirectionTests|MessageEqualityTests|ConversationMergeTests|PendingMessageTests|SendQueueTests|InMemorySendQueueStorageTests|InMemoryMessageCacheTests|FileSendQueueStorageTests|ReplyContextModelTests|SyncManager|PSKEnvelopeTests|PSKExchangeURITests|PSKStateTests"
+          --filter "ChatErrorTests|CustomAmountTests/|MessageCodableTests|MessageDirectionTests|MessageEqualityTests|ConversationMergeTests|PendingMessageTests|SendQueueTests|InMemorySendQueueStorageTests|InMemoryMessageCacheTests|FileSendQueueStorageTests|ReplyContextModelTests|SyncManager|PSKEnvelopeTests|PSKExchangeURITests|PSKStateTests|PublicKeyCacheTests|DiscoveredKeyTests|PSKRatchetTests"
 
   cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Run tests (batch 2 — unit + non-crypto)
       run: >-
         swift test -v
-        --filter "ChatErrorTests|CustomAmountTests/|MessageCodableTests|MessageDirectionTests|MessageEqualityTests|ConversationMergeTests|PendingMessageTests|SendQueueTests|InMemorySendQueueStorageTests|InMemoryMessageCacheTests|FileSendQueueStorageTests|ReplyContextModelTests|SyncManager|PSKEnvelopeTests|PSKExchangeURITests|PSKStateTests"
+        --filter "ChatErrorTests|CustomAmountTests/|MessageCodableTests|MessageDirectionTests|MessageEqualityTests|ConversationMergeTests|PendingMessageTests|SendQueueTests|InMemorySendQueueStorageTests|InMemoryMessageCacheTests|FileSendQueueStorageTests|ReplyContextModelTests|SyncManager|PSKEnvelopeTests|PSKExchangeURITests|PSKStateTests|PublicKeyCacheTests|DiscoveredKeyTests|PSKRatchetTests"


### PR DESCRIPTION
## Summary
- Add `PublicKeyCacheTests`, `DiscoveredKeyTests`, and `PSKRatchetTests` to CI batch 2 on both Linux and macOS — these test suites existed but were not included in any CI filter
- Add `KeyVerification` to Linux batch 1 filter (macOS already had it)

All 3 added suites are lightweight (no heavy encrypt/decrypt cycles), so they should not trigger the CryptoKit/BoringSSL crashes that affect the excluded suites.

## Test plan
- [ ] Linux CI passes with the new test suites in batch 2
- [ ] macOS CI passes with the new test suites in batch 2
- [ ] KeyVerificationTests now runs on Linux (batch 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)