### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,17 +3,26 @@ name: Documentation
 on:
   push:
     branches: [ main ]
+    paths:
+      - "Sources/**"
+      - "Package.swift"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
@@ -37,6 +46,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,15 +3,33 @@ name: Linux
 on:
   push:
     branches: ["main"]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/linux.yml"
   pull_request:
     branches: ["main"]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/linux.yml"
+
+concurrency:
+  group: linux-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
+    # Deliberate Linux compile via the official swift:6.0 container on GitHub-hosted Linux.
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build
         run: swift build -v
@@ -39,8 +57,9 @@ jobs:
   cli:
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build CLI
         run: swift build --product algochat -v

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -3,14 +3,31 @@ name: macOS
 on:
   push:
     branches: ["main"]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/macOS.yml"
   pull_request:
     branches: ["main"]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/macOS.yml"
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     # Run tests in 2 batches. Limit ~12 suites per batch — too many


### PR DESCRIPTION
Standardizes the GitHub Actions workflows for this PUBLIC swift-spm repo.

## Changes
- **macOS.yml** (push/PR CI): added a swift-spm `paths:` filter (`Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, plus this workflow file) and a `concurrency:` group with `cancel-in-progress`. Bumped `actions/checkout@v4` -> `@v5` and added `timeout-minutes`. Runner stays `macos-latest` (correct for a public repo).
- **linux.yml** (push/PR CI): same `paths:` filter + `concurrency:` group. Bumped checkout to `@v5`, added `timeout-minutes` to both jobs. Kept the deliberate Linux compile on GitHub-hosted `ubuntu-latest` (via the `swift:6.0` container) with a clarifying comment.
- **docs.yml** (push-only DocC -> GitHub Pages deploy): added a site-source-scoped `paths:` filter (`Sources/**`, `Package.swift`) so docs only rebuild on source changes, plus a `concurrency: { group: pages, cancel-in-progress: true }`. Bumped checkout to `@v5`, added `timeout-minutes`. Runners unchanged (public-correct).

A README/docs/LICENSE-only change now matches no path set and triggers no CI.

All runners were already GitHub-hosted (correct for a PUBLIC repo); no runner changes were required.

Mirrors the CorvidLabs/merlin CI standard.